### PR TITLE
fix(bug)：修复全局页面底部Footer年份展示数据不对问题

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="footer">
-    <div class="left">Copyright © 2019-2021 十三. All rights reserved.</div>
+    <div class="left">Copyright © 2019-{{ state.year }} 十三. All rights reserved.</div>
     <div class="right">
       <a target="_blank" href="https://github.com/newbee-ltd/vue3-admin">vue3-admin Version 3.0.0</a>
     </div>
@@ -8,6 +8,11 @@
 </template>
 
 <script setup>
+import { reactive } from 'vue'
+
+const state = reactive({
+  year: new Date().getFullYear()
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
现在的项目全局页面底部展示时间现在的都是2019-2021年，结束年份2021年应该为动态的年份，这个提交修复了年份数据展示的问题，希望作者大大有空可以看看哦 ^_^ 